### PR TITLE
Remove atlassian tracking on google.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
 				<version>${amps.version}</version>
 				<extensions>true</extensions>
 				<configuration>
+					<allowGoogleTracking>false</allowGoogleTracking>
 					<products>
 						<product>
 							<id>bitbucket</id>


### PR DESCRIPTION
Why is Atlassian tracking automatically, remote requests like this should be opt-in.